### PR TITLE
Version 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [v2.0.0] - Click API v1-22.3.01.00 - 2023-01-23
+### Breaking 
+- Deprecating Node versions <12
+### Security
+- Update jsonwebtoken package to 9.0.0 addressing CVE-2022-23529
+
+### Changed
+- Added support for version v1-22.3.01.00 of the DocuSign Click API.
+- Updated the SDK release version.
+
 ## [v1.2.2] - Click API v1-22.3.01.00 - 2022-10-27
 ### Changed
 - Added support for version v1-22.3.01.00 of the DocuSign Click API.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This client has the following external dependencies:
 ### Optional:
 
 - Async v2.6.2
-- Jsonwebtoken v8.2.0
+- Jsonwebtoken v9.0.0
 - Passport-oauth2
 - Path
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusign-click",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "DocuSign Node.js API client.",
   "license": "MIT",
   "main": "src/index.js",
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "csv-stringify": "^1.0.0",
-    "jsonwebtoken": "8.2.0",
+    "jsonwebtoken": "^9.0.0",
     "passport-oauth2": "^1.6.1",
     "safe-buffer": "^5.1.2",
     "superagent": "3.8.2"

--- a/src/api/AccountsApi.js
+++ b/src/api/AccountsApi.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapAgreementsResponse.js
+++ b/src/model/ClickwrapAgreementsResponse.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapDeleteResponse.js
+++ b/src/model/ClickwrapDeleteResponse.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapRequest.js
+++ b/src/model/ClickwrapRequest.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapScheduledReacceptance.js
+++ b/src/model/ClickwrapScheduledReacceptance.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapTransferRequest.js
+++ b/src/model/ClickwrapTransferRequest.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapVersion.js
+++ b/src/model/ClickwrapVersion.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapVersionDeleteResponse.js
+++ b/src/model/ClickwrapVersionDeleteResponse.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapVersionResponse.js
+++ b/src/model/ClickwrapVersionResponse.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapVersionSummaryResponse.js
+++ b/src/model/ClickwrapVersionSummaryResponse.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapVersionsDeleteResponse.js
+++ b/src/model/ClickwrapVersionsDeleteResponse.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapVersionsPagedResponse.js
+++ b/src/model/ClickwrapVersionsPagedResponse.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapVersionsResponse.js
+++ b/src/model/ClickwrapVersionsResponse.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ClickwrapsDeleteResponse.js
+++ b/src/model/ClickwrapsDeleteResponse.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/DataField.js
+++ b/src/model/DataField.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/DisplaySettings.js
+++ b/src/model/DisplaySettings.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/Document.js
+++ b/src/model/Document.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ErrorDetails.js
+++ b/src/model/ErrorDetails.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ServiceInformation.js
+++ b/src/model/ServiceInformation.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/ServiceVersion.js
+++ b/src/model/ServiceVersion.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/UserAgreementRequest.js
+++ b/src/model/UserAgreementRequest.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com

--- a/src/model/UserAgreementResponse.js
+++ b/src/model/UserAgreementResponse.js
@@ -1,6 +1,6 @@
 /**
  * DocuSign Click API
- * DocuSign Click lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable clickwrap solution in your DocuSign integrations.
+ * Elastic signing (also known as DocuSign Click)  lets you capture consent to standard agreement terms with a single click: terms and conditions, terms of service, terms of use, privacy policies, and more. The Click API lets you include this customizable elastic template solution in your DocuSign integrations.
  *
  * OpenAPI spec version: v1
  * Contact: devcenter@docusign.com


### PR DESCRIPTION
### Breaking 
- Deprecating Node versions <12
### Security
- Update jsonwebtoken package to 9.0.0 addressing CVE-2022-23529

### Changed
- Added support for version v1-22.3.01.00 of the DocuSign Click API.
- Updated the SDK release version.
